### PR TITLE
Adds mediaarea repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM lsiobase/ubuntu:xenial
 ARG DEBIAN_FRONTEND="noninteractive"
 
 RUN \
+ echo "**** install apt-transport-https ****" && \
+ apt-get update && \
+ apt-get install -y apt-transport-https && \
  echo "**** add mono repository ****" && \
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
  echo "deb http://download.mono-project.com/repo/ubuntu xenial main" | tee /etc/apt/sources.list.d/mono-official.list && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ RUN \
  echo "**** add mono repository ****" && \
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
  echo "deb http://download.mono-project.com/repo/ubuntu xenial main" | tee /etc/apt/sources.list.d/mono-official.list && \
+ echo "**** add mediaarea repository ****" && \
+ apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5CDF62C7AE05CC847657390C10E11090EC0E438 && \
+ echo "deb https://mediaarea.net/repo/deb/ubuntu xenial main" | tee /etc/apt/sources.list.d/mediaarea.list && \
  echo "**** install packages ****" && \
  apt-get update && \
  apt-get install -y \


### PR DESCRIPTION
Fixes https://github.com/Radarr/Radarr/issues/2668#issuecomment-376310514

This upgrades mediainfo since the mediainfo package in ubuntu 16.04 is quite old.

- Had to duplicate the `apt-get update` because you can't run `update` against a HTTPS repo without having the transport installed and installing that requires an update.
- The mediaarea GPG key fingerprint can be verified at https://mediaarea.net/en/Repos

Thanks for maintaining this!