### PR TITLE
fix(Dockerfile): Swiches mono repo to HTTPS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN \
  apt-get install -y apt-transport-https && \
  echo "**** add mono repository ****" && \
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
- echo "deb http://download.mono-project.com/repo/ubuntu xenial main" | tee /etc/apt/sources.list.d/mono-official.list && \
+ echo "deb https://download.mono-project.com/repo/ubuntu xenial main" | tee /etc/apt/sources.list.d/mono-official.list && \
  echo "**** add mediaarea repository ****" && \
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5CDF62C7AE05CC847657390C10E11090EC0E438 && \
  echo "deb https://mediaarea.net/repo/deb/ubuntu xenial main" | tee /etc/apt/sources.list.d/mediaarea.list && \


### PR DESCRIPTION
As the title states, switches mono repo to HTTPS. Builds fine locally.

Related: https://github.com/linuxserver/docker-radarr/pull/27

