### PR TITLE
bump mono to 5.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN \
 	apt-transport-https && \
  echo "**** add mono repository ****" && \
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
- echo "deb http://download.mono-project.com/repo/ubuntu bionic/snapshots/5.14 main" | tee /etc/apt/sources.list.d/mono-official.list && \
+ echo "deb http://download.mono-project.com/repo/ubuntu bionic/snapshots/5.20 main" | tee /etc/apt/sources.list.d/mono-official.list && \
  echo "**** add mediaarea repository ****" && \
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5CDF62C7AE05CC847657390C10E11090EC0E438 && \
  echo "deb https://mediaarea.net/repo/deb/ubuntu bionic main" | tee /etc/apt/sources.list.d/mediaarea.list && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -13,7 +13,7 @@ RUN \
 	apt-transport-https && \
  echo "**** add mono repository ****" && \
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
- echo "deb http://download.mono-project.com/repo/ubuntu bionic/snapshots/5.14 main" | tee /etc/apt/sources.list.d/mono-official.list && \
+ echo "deb http://download.mono-project.com/repo/ubuntu bionic/snapshots/5.20 main" | tee /etc/apt/sources.list.d/mono-official.list && \
  echo "**** add mediaarea repository ****" && \
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5CDF62C7AE05CC847657390C10E11090EC0E438 && \
  echo "deb https://mediaarea.net/repo/deb/ubuntu bionic main" | tee /etc/apt/sources.list.d/mediaarea.list && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -13,7 +13,7 @@ RUN \
 	apt-transport-https && \
  echo "**** add mono repository ****" && \
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
- echo "deb http://download.mono-project.com/repo/ubuntu bionic/snapshots/5.14 main" | tee /etc/apt/sources.list.d/mono-official.list && \
+ echo "deb http://download.mono-project.com/repo/ubuntu bionic/snapshots/5.20 main" | tee /etc/apt/sources.list.d/mono-official.list && \
  echo "**** add mediaarea repository ****" && \
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5CDF62C7AE05CC847657390C10E11090EC0E438 && \
  echo "deb https://mediaarea.net/repo/deb/ubuntu bionic main" | tee /etc/apt/sources.list.d/mediaarea.list && \


### PR DESCRIPTION
This will bump downstream to Mono 5.20 as stable. 
Sonarr specifically addressed the reason we held back to 5.14 with the Jackett connection and indexer timeouts. 
The downstream Repos also still have a 5.14 tag for users that might have issues with 5.20. 

After this is merged I will fire off Package triggers for the RR branches. 